### PR TITLE
Move operation of downloading tarball from Dockerfile to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode
 volumes
 /docker-compose.yml
+packages/*
+!packages/.gitkeep

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
 # Makefile for hadoop docler build
 
+# basic configuration
+hadoop_version := 3.3.1
+hive_version := 3.1.2
+
+# common url
+hadoop_url := https://www.apache.org/dist/hadoop/common/hadoop-$(hadoop_version)/hadoop-$(hadoop_version).tar.gz
+hive_url := https://downloads.apache.org/hive/hive-$(hive_version)/apache-hive-$(hive_version)-bin.tar.gz
+
 uid := $(shell id -u)
 gid := $(uid)
 
@@ -16,17 +24,26 @@ build_network:
 	-docker network create hadoop-docker-bridge
 
 # build images for different targets
-build_hadoop_images:
+build_hadoop_images: download_hadoop_tarball
 	docker build $(build_flag) -t wechar/cluster-base ./base
-	docker build $(build_flag) -t wechar/hadoop ./hadoop
+	docker build $(build_flag) --build-arg HADOOP_VERSION=$(hadoop_version) -t wechar/hadoop -f ./hadoop/Dockerfile .
 	$(eval uid=$(shell echo $$(($(uid)+1))))
 
 build_mysql_images: build_hadoop_images
 	docker build $(build_flag) -t wechar/mysql ./mysql
 
-build_hive_images: build_mysql_images
-	docker build $(build_flag) -t wechar/hive ./hive
+build_hive_images: build_mysql_images download_hive_tarball
+	docker build $(build_flag) --build-arg HIVE_VERSION=$(hive_version) -t wechar/hive -f ./hive/Dockerfile .
 	$(eval uid=$(shell echo $$(($(uid)+1))))
+
+# download tarballs
+download_hadoop_tarball:
+	mkdir -p ./packages
+	test -f ./packages/hadoop-$(hadoop_version).tar.gz && echo "hadoop tarball already exists" || curl -SL $(hadoop_url) -o ./packages/hadoop-$(hadoop_version).tar.gz
+
+download_hive_tarball:
+	mkdir -p ./packages
+	test -f ./packages/apache-hive-$(hive_version)-bin.tar.gz && echo "hive tarball already exists" || curl -SL "$(hive_url)" -o ./packages/apache-hive-$(hive_version)-bin.tar.gz
 
 # clean the images
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The big data components are optional while starting up the cluster.
 - docker, docker-compose
 - make
 - sed
+- curl
 
 ## Usage
 
@@ -36,6 +37,7 @@ make run target=hadoop
 ```
 docker-compose start
 ```
+You can easily change the component version for your requirements in the `Makefile` file. Further more, if you want to test the non-community release version, i.e. components modified and compiled by yourself, you can place your compiled tarball in `packages` directory, **do not forget to keep the version number same as configuration in `Makefile`**.
 ### 3. stop containers
 - remove containers when stopping:
 ```

--- a/hadoop/Dockerfile
+++ b/hadoop/Dockerfile
@@ -6,18 +6,11 @@ WORKDIR /root
 RUN echo "hadoop ALL=NOPASSWD: ALL" > "/etc/sudoers.d/hadoop-docker"
 
 # install hadoop
-RUN curl -SL https://dist.apache.org/repos/dist/release/hadoop/common/KEYS -o /tmp/KEYS \
-    && gpg --import /tmp/KEYS \
-    && rm -rf /tmp/KEYS
-
 ARG HADOOP_VERSION="3.3.1"
-ARG HADOOP_URL="https://www.apache.org/dist/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz"
 
-RUN curl -SL "$HADOOP_URL" -o /tmp/hadoop.tar.gz \
-    && curl -sSL "$HADOOP_URL.asc" -o /tmp/hadoop.tar.gz.asc \
-    && gpg --verify /tmp/hadoop.tar.gz.asc \
-    && tar -xvf /tmp/hadoop.tar.gz -C /opt/ \
-    && rm /tmp/hadoop.tar.gz*
+COPY packages/hadoop-$HADOOP_VERSION.tar.gz /tmp/hadoop.tar.gz
+RUN tar -xvf /tmp/hadoop.tar.gz -C /opt/ \
+    && rm /tmp/hadoop.tar.gz
 
 ENV HADOOP_HOME /usr/share/hadoop
 
@@ -28,11 +21,11 @@ RUN sed -i '/export JAVA_HOME/ s#.*#export JAVA_HOME=/usr/lib/jvm/java-8-openjdk
 # RUN sed -i '$a export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64' $HADOOP_HOME/etc/hadoop/yarn-env.sh
 
 # copy the config files
-ADD configs/core-site.xml $HADOOP_HOME/etc/hadoop/core-site.xml
-ADD configs/hdfs-site.xml $HADOOP_HOME/etc/hadoop/hdfs-site.xml
-ADD configs/yarn-site.xml $HADOOP_HOME/etc/hadoop/yarn-site.xml
-ADD configs/mapred-site.xml $HADOOP_HOME/etc/hadoop/mapred-site.xml
-ADD configs/workers $HADOOP_HOME/etc/hadoop/workers
+ADD hadoop/configs/core-site.xml $HADOOP_HOME/etc/hadoop/core-site.xml
+ADD hadoop/configs/hdfs-site.xml $HADOOP_HOME/etc/hadoop/hdfs-site.xml
+ADD hadoop/configs/yarn-site.xml $HADOOP_HOME/etc/hadoop/yarn-site.xml
+ADD hadoop/configs/mapred-site.xml $HADOOP_HOME/etc/hadoop/mapred-site.xml
+ADD hadoop/configs/workers $HADOOP_HOME/etc/hadoop/workers
 
 # hadoop logs and data node path for all containers
 RUN mkdir $HADOOP_HOME/logs \
@@ -51,9 +44,9 @@ RUN groupadd -g $GID hdfs \
     && chown -R hadoop:hdfs $HADOOP_HOME/
 
 # start script
-ADD namenode-run.sh /dockerentry/namenode-run.sh
+ADD hadoop/namenode-run.sh /dockerentry/namenode-run.sh
 RUN chown hadoop /dockerentry/namenode-run.sh
-ADD resourcemanager-run.sh /dockerentry/resourcemanager-run.sh
+ADD hadoop/resourcemanager-run.sh /dockerentry/resourcemanager-run.sh
 RUN chown hadoop /dockerentry/resourcemanager-run.sh
-ADD secondarynamenode-run.sh /dockerentry/secondarynamenode-run.sh
+ADD hadoop/secondarynamenode-run.sh /dockerentry/secondarynamenode-run.sh
 RUN chown hadoop /dockerentry/secondarynamenode-run.sh

--- a/hive/Dockerfile
+++ b/hive/Dockerfile
@@ -7,26 +7,19 @@ WORKDIR /root
 RUN echo "hive ALL=NOPASSWD: ALL" > "/etc/sudoers.d/hive-docker"
 
 # install hive
-RUN curl -sSL https://downloads.apache.org/hive/KEYS -o /tmp/KEYS \
-    && gpg --import /tmp/KEYS \
-    && rm -rf /tmp/KEYS
-
 ARG HIVE_VERSION="3.1.2"
-ARG HIVE_URL="https://downloads.apache.org/hive/hive-${HIVE_VERSION}/apache-hive-${HIVE_VERSION}-bin.tar.gz"
 
-RUN curl -SL "${HIVE_URL}" -o /tmp/hive.tar.gz \
-    && curl -sSL "${HIVE_URL}.asc" -o /tmp/hive.tar.gz.asc \
-    && gpg --verify /tmp/hive.tar.gz.asc \
-    && tar -xvf /tmp/hive.tar.gz -C /opt/ \
-    && rm /tmp/hive.tar.gz*
+COPY packages/apache-hive-${HIVE_VERSION}-bin.tar.gz /tmp/hive.tar.gz
+RUN tar -xvf /tmp/hive.tar.gz -C /opt/ \
+    && rm /tmp/hive.tar.gz
 
 ENV HIVE_HOME /usr/share/hive
 
 RUN ln -s /opt/apache-hive-${HIVE_VERSION}-bin $HIVE_HOME
 
 # copy the config files
-ADD configs/hivemetastore-site.xml $HIVE_HOME/conf/hivemetastore-site.xml
-ADD configs/hive-env.sh $HIVE_HOME/conf/hive-env.sh
+ADD hive/configs/hivemetastore-site.xml $HIVE_HOME/conf/hivemetastore-site.xml
+ADD hive/configs/hive-env.sh $HIVE_HOME/conf/hive-env.sh
 
 # environment variables for all users
 RUN echo "export HIVE_HOME=/usr/share/hive" >> ~/.bash_profile \
@@ -47,7 +40,7 @@ ARG GID=1000
 RUN useradd -g $GID -u $UID -k /root -rm -s /bin/bash hive \
     && chown -R hive:hdfs $HIVE_HOME/
 
-ADD run.sh /dockerentry/run.sh
+ADD hive/run.sh /dockerentry/run.sh
 RUN chmod a+x /dockerentry/run.sh
 
 CMD ["/dockerentry/run.sh"]


### PR DESCRIPTION
**What is this PR?**

This PR move the downloading tarball operations from Dockerfile to Makefile.

**Why needs this PR?**
1. cache tarball on local, otherwise we should download the tarball each time we modify the Dockerfile.
2. easy to use customed tarball for testing